### PR TITLE
Fix for issue2:  Liburing installs into /usr/lib

### DIFF
--- a/bld
+++ b/bld
@@ -20,7 +20,7 @@ if [ "$1" == "tests" ]; then
 fi
 
 if [ "$1" == "install" ]; then
-  ar crs libmrloop.a mrloop.o /usr/local/lib/liburing.a
+  ar crs libmrloop.a mrloop.o /usr/lib/liburing.a
   mv libmrloop.a /usr/local/lib
   cp mrloop.h /usr/local/include
 fi


### PR DESCRIPTION
```
git clone https://github.com/axboe/liburing.git
cd liburing
make
sudo make install
```

Puts liburing.a in /usr/lib and mrloop's bld file looks for it in /usr/local/lib so this PR changes it. 
